### PR TITLE
Fix typo in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This app is build with [ASP.NET Core Blazor](https://docs.microsoft.com/en-us/as
 
 ## How to get started contributing code
 
-### Prequisites
+### Prerequisites
 
 - Have the .NET Core SDK installed (v5)
 


### PR DESCRIPTION
## Summary
- fix heading typo in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68443722593c8321abaa98590f8b8fea