### PR TITLE
Fix deprecated Router.PreferExactMatches warning

### DIFF
--- a/src/Client/App.razor
+++ b/src/Client/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
+﻿<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" />
     </Found>


### PR DESCRIPTION
This PR fixes the deprecated Router.PreferExactMatches warning by removing the obsolete property assignment from the Blazor Router configuration. The PreferExactMatches property is no longer needed in .NET 9 as this behavior is now the default.