### PR TITLE
Fix deployment: Update GitHub Actions to use .NET 9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.*'
-        include-prerelease: true
+        dotnet-version: '9.0.*'
+        include-prerelease: false
 
     - name: Build with dotnet
       working-directory: ./src/Server


### PR DESCRIPTION
This PR fixes the deployment failure identified in [run #15511141343](https://github.com/petermarnef/teammoodboard/actions/runs/15511141343).

## Problem
The deployment was failing because the GitHub Actions workflow was still configured to use .NET 6.0, but the project has been upgraded to target .NET 9.0.

## Solution
- ✅ Updated  from  to  in the workflow
- ✅ Updated  to v4 for better compatibility  
- ✅ Updated  to v4 for proper .NET 9 support
- ✅ Removed  flag since .NET 9 is now stable

## Testing
After merging this PR, the deployment pipeline should successfully:
1. Set up .NET 9.0 SDK in the build environment
2. Build the project targeting .NET 9.0
3. Deploy to Azure without SDK compatibility issues

Fixes the build error: *NETSDK1045: The current .NET SDK does not support targeting .NET 9.0*